### PR TITLE
Fix some warnings that manifest in the Crypt-DSA test suite

### DIFF
--- a/lib/Convert/PEM.pm
+++ b/lib/Convert/PEM.pm
@@ -361,7 +361,7 @@ sub encrypt {
     my $cbc = Convert::PEM::CBC->new(
                     IV            =>    $iv,
                     Cipher        =>    $cm->new($key) );
-    my $iv = uc join '', unpack "H*", $cbc->iv;
+    $iv = uc join '', unpack "H*", $cbc->iv;
     my $buf = $cbc->encrypt($param{Plaintext}) or
         return $pem->error("Encryption failed: " . $cbc->errstr);
     ($buf, "$ctype,$iv");

--- a/lib/Convert/PEM.pm
+++ b/lib/Convert/PEM.pm
@@ -50,11 +50,11 @@ sub _getform {
     my $pem = shift;
     my %param = @_;
 
-    my $in = uc($param{InForm}) || 'PEM';
+    my $in = uc($param{InForm} || 'PEM');
     $in =~ m/^(PEM|DER)$/ or return $pem->error("Invalid InForm '$in': must be PEM or DER");
     $pem->{InForm} = $in;
 
-    my $out = uc($param{OutForm}) || 'PEM';
+    my $out = uc($param{OutForm} || 'PEM');
     $out =~ m/^(PEM|DER)$/ or return $pem->error("Invalid OutForm '$out': must be PEM or DER");
     $pem->{OutForm} = $out;
     $pem;


### PR DESCRIPTION
The Crypt-DSA test suite fails with Convert-PEM 0.12 (was passing with 0.09):
```
$ cd Crypt-DSA-1.17
$ make test AUTOMATED_TESTING=1
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'inc', 'blib/lib', 'blib/arch')" t/*.t xt/*.t
# Testing Crypt::DSA 1.17
t/00-compile.t .. ok
t/01-util.t ..... ok
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
t/02-sign.t ..... ok
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
t/03-keygen.t ... ok
"my" variable $iv masks earlier declaration in same scope at /usr/share/perl5/vendor_perl/Convert/PEM.pm line 364.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $cur_part in hash element at /builddir/build/BUILD/perl-Crypt-DSA-1.17-build/Crypt-DSA-1.17/blib/lib/Crypt/DSA/KeyChain.pm line 60.
Use of uninitialized value $param{"InForm"} in uc at /usr/share/perl5/vendor_perl/Convert/PEM.pm line 53.
Use of uninitialized value $param{"OutForm"} in uc at /usr/share/perl5/vendor_perl/Convert/PEM.pm line 57.
Use of uninitialized value $param{"InForm"} in uc at /usr/share/perl5/vendor_perl/Convert/PEM.pm line 53.
Use of uninitialized value $param{"OutForm"} in uc at /usr/share/perl5/vendor_perl/Convert/PEM.pm line 57.
#   Failed test 'Load key using Crypt::DSA::key'
#   at t/04-pem.t line 46.
Can't call method "p" on an undefined value at t/04-pem.t line 47.
# Looks like your test exited with 255 just after 7.
t/04-pem.t ...... 
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 20/26 subtests 
# This takes a couple of minutes on slower machines.
t/06-fips.t ..... ok
"my" variable $iv masks earlier declaration in same scope at /usr/share/perl5/vendor_perl/Convert/PEM.pm line 364.
Use of uninitialized value $param{"InForm"} in uc at /usr/share/perl5/vendor_perl/Convert/PEM.pm line 53.
Use of uninitialized value $param{"OutForm"} in uc at /usr/share/perl5/vendor_perl/Convert/PEM.pm line 57.
#   Failed test 'Parsed key'
#   at t/07-openid.t line 39.
Can't call method "p" on an undefined value at t/07-openid.t line 40.
# Looks like your test exited with 255 just after 2.
t/07-openid.t ... 
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 10/11 subtests 
xt/meta.t ....... ok
xt/pmv.t ........ ok
xt/pod.t ........ ok
Test Summary Report
-------------------
t/04-pem.t    (Wstat: 65280 (exited 255) Tests: 7 Failed: 1)
  Failed test:  7
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 26 tests but ran 7.
t/07-openid.t (Wstat: 65280 (exited 255) Tests: 2 Failed: 1)
  Failed test:  2
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 11 tests but ran 2.
Files=10, Tests=78, 143 wallclock secs ( 0.02 usr  0.00 sys + 141.51 cusr  0.20 csys = 141.73 CPU)
Result: FAIL
Failed 2/10 test programs. 2/78 subtests failed.
make: *** [Makefile:778: test_dynamic] Error 255
```
There are a lot of warnings originating from Crypt/DSA/KeyChain.pm that aren't relevant here but there are also some warnings from Convert::PEM and of course the test failures with the current version.

This PR should address the warnings from Convert::PEM but I haven't been able to figure out the cause of the test failures, at least not yet.